### PR TITLE
update SLE16 and Leap16 Client Tools with new URLs

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -601,8 +601,7 @@ checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-# TODO: To be changed as soon as the real client tools are ready!
-repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/
+repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/
 
 # This is expected. openSUSE Leap 16.0 client tools are valid for all openSUSE Leap 16.X releases
 [opensuse_leap16_0-uyuni-client-devel]
@@ -613,8 +612,7 @@ checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-# TODO: To be changed as soon as the real client tools are ready!
-repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/
+repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/
 
 [opensuse_micro5_5]
 checksum = sha256
@@ -1102,8 +1100,7 @@ checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-# TODO: To be changed as soon as the real client tools are ready!
-repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/
+repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE16-Uyuni-Client-Tools/SLE_16/
 
 [sles16-0-devel-uyuni-client]
 name     = Uyuni Client Tools for SLES16.0 %(arch)s (Development)
@@ -1113,8 +1110,7 @@ checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-# TODO: To be changed as soon as the real client tools are ready!
-repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/
+repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE16-Uyuni-Client-Tools/SLE_16/
 
 [sles16-sap-0-uyuni-client]
 name     = Uyuni Client Tools for SLES16.0 SAP %(arch)s
@@ -1124,8 +1120,7 @@ checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-# TODO: To be changed as soon as the real client tools are ready!
-repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/
+repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE16-Uyuni-Client-Tools/SLE_16/
 
 [sles16-sap-0-devel-uyuni-client]
 name     = Uyuni Client Tools for SLES16.0 SAP %(arch)s (Development)
@@ -1135,8 +1130,7 @@ checksum = sha256
 gpgkey_url = %(_uyuni_gpgkey_url)s
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-# TODO: To be changed as soon as the real client tools are ready!
-repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/
+repo_url = https://cdn.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE16-Uyuni-Client-Tools/SLE_16/
 
 [suse-microos-5.2-uyuni-client]
 name     = Uyuni Client Tools for SUSE MicroOS 5.2 %(arch)s


### PR DESCRIPTION
## What does this PR change?

Update the URLs for SLE16 and Leap 16 Uyuni Client Tools.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Doc is already WIP

- [x] **DONE**

## Test coverage
- already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
